### PR TITLE
Add a link to `velodyne_decoder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Contributions are welcome! Please [check out](contributing.md) our guidelines.
 - [Velodyne](https://velodynelidar.com/) - Ouster and Velodyne announced the successful completion of their *merger* of equals, effective February 10, 2023. Velodyne was a mechanical and solid-state LIDAR manufacturer. The headquarter is in San Jose, California, USA.
   - [YouTube channel :red_circle:](https://www.youtube.com/user/VelodyneLiDAR)
   - [ROS driver :octocat:](https://github.com/ros-drivers/velodyne)
+  - [C++/Python library :octocat:](https://github.com/valgur/velodyne_decoder)
 - [Ouster](https://ouster.com/) - LIDAR manufacturer, specializing in digital-spinning LiDARs. Ouster is headquartered in San Francisco, USA.
   - [YouTube channel :red_circle:](https://www.youtube.com/c/Ouster-lidar)
   - [GitHub organization :octocat:](https://github.com/ouster-lidar)


### PR DESCRIPTION
[velodyne_decoder](https://github.com/valgur/velodyne_decoder) is an unofficial C++/Python library for Velodyne data. It is based on the unofficial ROS driver already listed here, but has been extensively improved to be fully featured and much more convenient to use. It's basically the only tool available that comes close to match the feature-set and accuracy of the official [VelodynePlugin](https://gitlab.kitware.com/LidarView/velodyneplugin) in [LidarView](https://gitlab.kitware.com/LidarView/lidarview).