### PR TITLE
Add ALFA Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contributions are welcome! Please [check out](contributing.md) our guidelines.
     - [Ground segmentation](#ground-segmentation)
     - [Simultaneous localization and mapping SLAM and LIDAR-based odometry and or mapping LOAM](#simultaneous-localization-and-mapping-slam-and-lidar-based-odometry-and-or-mapping-loam)
     - [Object detection and object tracking](#object-detection-and-object-tracking)
-    - [LIDAR-other-sensor calibration](#lidar-other-sensor-calibration)
+  - [LIDAR-other-sensor calibration](#lidar-other-sensor-calibration)
   - [Simulators](#simulators)
   - [Related awesome](#related-awesome)
   - [Others](#others)
@@ -163,6 +163,8 @@ Contributions are welcome! Please [check out](contributing.md) our guidelines.
 - [Baidu Apollo](https://apollo.auto/) - Apollo is a popular framework which accelerates the development, testing, and deployment of Autonomous Vehicles.
   - [GitHub repository ![](https://img.shields.io/badge/github-black?style=flat-square&logo=github)](https://github.com/ApolloAuto/apollo)
   - [YouTube channel ![](https://img.shields.io/badge/youtube-red?style=flat-square&logo=youtube)](https://www.youtube.com/c/ApolloAuto)
+- [ALFA Framework ![](https://img.shields.io/badge/paper-blue?style=flat-square&logo=semanticscholar)](https://ieeexplore.ieee.org/document/11024231) - An open-source framework for developing processing algorithms, with a focus on embedded platforms and hardware acceleration.
+  - [GitHub repository ![](https://img.shields.io/badge/github-black?style=flat-square&logo=github) ![](https://img.shields.io/badge/ROS-2-34aec5?style=flat-square&logo=ros)](https://github.com/alfa-project/alfa-framework)
 
 ## Algorithms
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contributions are welcome! Please [check out](contributing.md) our guidelines.
     - [Ground segmentation](#ground-segmentation)
     - [Simultaneous localization and mapping SLAM and LIDAR-based odometry and or mapping LOAM](#simultaneous-localization-and-mapping-slam-and-lidar-based-odometry-and-or-mapping-loam)
     - [Object detection and object tracking](#object-detection-and-object-tracking)
-  - [LIDAR-other-sensor calibration](#lidar-other-sensor-calibration)
+    - [LIDAR-other-sensor calibration](#lidar-other-sensor-calibration)
   - [Simulators](#simulators)
   - [Related awesome](#related-awesome)
   - [Others](#others)
@@ -254,7 +254,7 @@ Real-Time LIDAR-Based Urban Road and Sidewalk Detection for Autonomous Vehicles
   - [GitHub ![](https://img.shields.io/badge/github-black?style=flat-square&logo=github)](https://autowarefoundation.github.io/autoware.universe/main/perception/detection_by_tracker/) ![](https://img.shields.io/badge/ROS-2-34aec5?style=flat-square&logo=ros)
   - [YouTube video ![](https://img.shields.io/badge/youtube-red?style=flat-square&logo=youtube)](https://www.youtube.com/watch?v=xSGCpb24dhI)
 
-## LIDAR-other-sensor calibration
+### LIDAR-other-sensor calibration
 
 - [direct_visual_lidar_calibration](https://koide3.github.io/direct_visual_lidar_calibration/) - General, Single-shot, Target-less, and Automatic LiDAR-Camera Extrinsic Calibration Toolbox
   - [GitHub repository ![](https://img.shields.io/badge/github-black?style=flat-square&logo=github)](https://github.com/koide3/direct_visual_lidar_calibration) ![](https://img.shields.io/badge/ROS-2-34aec5?style=flat-square&logo=ros)


### PR DESCRIPTION
Hi there,

Thanks for maintaining this awesome repository — it's an incredibly helpful resource for anyone getting started in the LiDAR field!

I’d like to suggest adding ALFA (Advanced LiDAR Framework for Automotive) to the list of LiDAR frameworks. ALFA is an open-source framework designed for the development and evaluation of LiDAR processing algorithms across a range of platforms. It supports:

- Sensor-agnostic algorithm development
- Desktop and embedded systems
- Hardware acceleration using FPGAs

The project is actively maintained and aims to lower the barrier to entry for newcomers working on real-time, resource-constrained LiDAR applications such as denoising, ground-segmentation and compression.

[GitHub](https://github.com/alfa-project/alfa-framework)
[Paper](https://ieeexplore.ieee.org/document/11024231)

PS: On a side note, I noticed that the Table of Contents and headers don't match for the _LIDAR-other-sensor calibration_  — the TOC points to a third-level header, but it's defined as ## in the README. Let me know If I must drop it in this PR.

Thanks again for the great work!